### PR TITLE
Fixed issue with population of scenario variables

### DIFF
--- a/internal/service/base/base.go
+++ b/internal/service/base/base.go
@@ -34,11 +34,19 @@ func GetCurrentConversations() map[string]Conversation {
 
 //AddConversation method adds the new conversation to the list of open conversations. This will be used for scenarios build
 func AddConversation(channel string, questionID int64, message dto.BaseChatMessage, variable string) {
-	updatedConversation := Conversation{
-		ScenarioID:         message.DictionaryMessage.ScenarioID,
-		ScenarioQuestionID: questionID,
-		LastQuestion:       message,
-		ReactionType:       message.DictionaryMessage.ReactionType,
+	updatedConversation := Conversation{}
+	if CurrentConversations[channel].ScenarioID != int64(0) {
+		updatedConversation = CurrentConversations[channel]
+		updatedConversation.ScenarioQuestionID = questionID
+		updatedConversation.LastQuestion = message
+		updatedConversation.ReactionType = message.DictionaryMessage.ReactionType
+	} else {
+		updatedConversation = Conversation{
+			ScenarioID:         message.DictionaryMessage.ScenarioID,
+			ScenarioQuestionID: questionID,
+			LastQuestion:       message,
+			ReactionType:       message.DictionaryMessage.ReactionType,
+		}
 	}
 
 	updatedConversation = AddConversationVariable(updatedConversation, variable)


### PR DESCRIPTION
In this pull-request I fixed the issue with population of variables list during execution of questions from scenario.
There was a bug, which doesn't updates properly the variables list, instead of it, the logic cleanup the old list and creates new one.