### PR TITLE
Fixed issue with wrong regexp for example events

### DIFF
--- a/events/cancelscenario/event.go
+++ b/events/cancelscenario/event.go
@@ -22,7 +22,7 @@ const (
 	//The migrations folder, which can be used for event installation or for event update
 	migrationDirectoryPath = "./events/cancelscenario/migrations"
 
-	regexChannel = `(?im)(?:[<#@])(\w+)(?:[>])`
+	regexChannel = `(?im)(?:[<#@]|(?:&lt;))(\w+)(?:[|>]|(?:&gt;))`
 )
 
 //EventStruct the struct for the event object. It will be used for initialisation of the event in defined-events.go file.

--- a/events/examplescenario/event.go
+++ b/events/examplescenario/event.go
@@ -25,7 +25,7 @@ const (
 	//The migrations folder, which can be used for event installation or for event update
 	migrationDirectoryPath = "./events/examplescenario/migrations"
 
-	regexChannel = `(?im)(?:[<#@])(\w+)(?:[>])`
+	regexChannel = `(?im)(?:[<#@]|(?:&lt;))(\w+)(?:[|>]|(?:&gt;))`
 
 	stepMessage = "What I need to write?"
 	stepChannel = "Where I need to post this message? If it's channel, the channel should be public."


### PR DESCRIPTION
There is a bad regexp used for parsing of channel name from the message