### PR TITLE
Fixed issue related to the wrong list of questions, which are empty

### DIFF
--- a/events/eventslist/event.go
+++ b/events/eventslist/event.go
@@ -41,6 +41,7 @@ func (e EListEvent) Execute(message dto.BaseChatMessage) (dto.BaseChatMessage, e
 	from events e
 	join scenarios s on e.id = s.event_id
 	join questions q on s.id = q.scenario_id
+	where q.question <> ''
 	`)
 	if err != nil {
 		message.Text = fmt.Sprintf("Hmm. I tried to get the list of the available events and I failed. Here is the error: ```%s```", err)


### PR DESCRIPTION
In the scenarios some questions can be without filled "question" field, so we need to exclude them from the list of eventslist event